### PR TITLE
Copyedit readme following Fivetran docs style

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ This package enriches your Fivetran data by doing the following:
 This package contains staging models, designed to work simultaneously with our [Pinterest Ads modeling package](https://github.com/fivetran/dbt_pinterest). The staging models:
 
 * Name columns consistently across all packages:
-* Boolean fields are prefixed with is_ or has_
-* Timestamps are appended with _at
-* ID primary keys are prefixed with the name of the table. For example, the campaign table's ID column is renamed campaign_id.
+    * Boolean fields are prefixed with `is_` or `has_`
+    * Timestamps are appended with `_at`
+    * ID primary keys are prefixed with the name of the table. For example, the campaign table's ID column is renamed `campaign_id`.
 
 ## Installation Instructions
 Check [dbt Hub](https://hub.getdbt.com/) for the latest installation instructions, or [read the dbt docs](https://docs.getdbt.com/docs/package-management) for more information on installing packages.
 
 ## Configuration
-By default this package will look for your Pinterest data in the `pinterest_ads` schema of your [target database](https://docs.getdbt.com/docs/running-a-dbt-project/using-the-command-line-interface/configure-your-profile). If this is not where your Pinterest Ads data is, please add the following configuration to your `dbt_project.yml` file:
+By default, this package will look for your Pinterest Ads data in the `pinterest_ads` schema of your [target database](https://docs.getdbt.com/docs/running-a-dbt-project/using-the-command-line-interface/configure-your-profile). If this is not where your Pinterest Ads data is, please add the following configuration to your `dbt_project.yml` file:
 
 ```yml
 # dbt_project.yml
@@ -33,8 +33,6 @@ vars:
     pinterest_schema: your_database_name
     pinterest_database: your_schema_name 
 ```
-
-For additional configurations for the source models, please visit the [Pinterest Ads source package](https://github.com/fivetran/dbt_pinterest_source).
 
 ## Contributions
 


### PR DESCRIPTION
Fixes small grammar issues. Corrects formatting errors. Removed redundant content.