### PR TITLE
doc(pinterest ads source README): modeling to transform change

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package enriches your Fivetran data by doing the following:
 
 ## Models
 
-This package contains staging models, designed to work simultaneously with our [Pinterest Ads modeling package](https://github.com/fivetran/dbt_pinterest) and our [multi-platform Ad Reporting package](https://github.com/fivetran/dbt_ad_reporting). The staging models:
+This package contains staging models, designed to work simultaneously with our [Pinterest Ads transformation package](https://github.com/fivetran/dbt_pinterest) and our [multi-platform Ad Reporting package](https://github.com/fivetran/dbt_ad_reporting). The staging models:
 
 * Name columns consistently across all packages:
     * Boolean fields are prefixed with `is_` or `has_`


### PR DESCRIPTION
Links https://fivetran.atlassian.net/browse/RD-190128

Changes mention of "modeling package" into "transformation package."